### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *__pycache__*
 *DS_Store*
 *.pyc
+*.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*__pycache__*
+*DS_Store*
+*.pyc


### PR DESCRIPTION
Ignore standard Python and Mac-produced files. This will ensure that unnecessary files aren't accidentally committed in the future.