### PR TITLE
Initialize offset_epoch to None

### DIFF
--- a/PIPS/class_photdata/__init__.py
+++ b/PIPS/class_photdata/__init__.py
@@ -63,6 +63,7 @@ class photdata:
         self.period_err = None
         self.amplitude = None
         self.amplitude_err = None
+        self.offset_epoch = None
         self.label = label
         self.band = ''
         self.epoch = None

--- a/PIPS/class_photdata/__init__.py
+++ b/PIPS/class_photdata/__init__.py
@@ -63,10 +63,10 @@ class photdata:
         self.period_err = None
         self.amplitude = None
         self.amplitude_err = None
-        self.offset_epoch = None
         self.label = label
         self.band = ''
         self.epoch = None
+        self.epoch_offset = None
         self.meanmag = None # based on best-fit function: requires period
         
     ##############


### PR DESCRIPTION
If offset_epoch isn't initially set to None, when the stellar models class is initialized before get_offset_epoch, an AttributeError is thrown.