### PR TITLE
pass p_min and p_max to get_multi_period

### DIFF
--- a/PIPS/class_photdata/__init__.py
+++ b/PIPS/class_photdata/__init__.py
@@ -467,6 +467,8 @@ class photdata:
 
         periods,period_errors,amplitudes = self.get_period_multi(
             N,
+            p_min=p_min,
+            p_max=p_max,
             model=model,
             Nterms=Nterms,
             **kwargs)


### PR DESCRIPTION
In amplitude_spectrum, p_min and p_max currently aren't being passed to get_multi_period.